### PR TITLE
Add compatibility with custom user models

### DIFF
--- a/ninja_apikey/models.py
+++ b/ninja_apikey/models.py
@@ -29,4 +29,4 @@ class APIKey(models.Model):
         return self.expires_at >= timezone.now()
 
     def __str__(self):
-        return f"{self.user.username}<{self.prefix}>"
+        return f"{self.user.get_username()}<{self.prefix}>"

--- a/ninja_apikey/tests.py
+++ b/ninja_apikey/tests.py
@@ -53,7 +53,7 @@ def test_apikey_check():
     key.hashed_key = key_data.hashed_key
     key.save()
     assert key
-    assert user.username in str(key)
+    assert user.get_username() in str(key)
     assert not check_apikey(key_data.key)
     assert not check_apikey(key.prefix)
     assert not check_apikey(f"{key_data.prefix}.{get_random_string(10)}")


### PR DESCRIPTION
When using a custom user model the `username` field may not exist on the model.

Django solves this by having a `get_username` method on the `User` model as documented [here](https://docs.djangoproject.com/en/4.2/ref/contrib/auth/#django.contrib.auth.models.User.get_username).

Since this is already required for a working custom user model I think it would be great to adhere to the same interface.